### PR TITLE
enable fedora 30 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,13 @@ env:
       OS_VERSION=7
       PYTHON_VERSION=2
     - OS=fedora
-      OS_VERSION=28
+      OS_VERSION=29
       PYTHON_VERSION=2
     - OS=fedora
-      OS_VERSION=28
+      OS_VERSION=29
       PYTHON_VERSION=3
     - OS=fedora
-      OS_VERSION=29
-      PYTHON_VERSION=2
-    - OS=fedora
-      OS_VERSION=29
+      OS_VERSION=30
       PYTHON_VERSION=3
 script:
  - pip install coveralls

--- a/python-dockerfile-parse.spec
+++ b/python-dockerfile-parse.spec
@@ -1,7 +1,6 @@
 %if 0%{?rhel} && 0%{?rhel} <= 7
 %{!?py2_build: %global py2_build %{__python2} setup.py build}
 %{!?py2_install: %global py2_install %{__python2} setup.py install --skip-build --root %{buildroot}}
-%global py2name python
 %bcond_with python3
 %if 0%{?rhel} <= 6
 %{!?__python2: %global __python2 /usr/bin/python2}
@@ -11,7 +10,6 @@
 %endif
 %else
 %bcond_without python3
-%global py2name python2
 %endif
 
 %bcond_without tests
@@ -36,22 +34,6 @@ BuildArch:      noarch
 %description
 %{summary}.
 
-%package -n python2-%{srcname}
-Summary:        %{summary}
-%{?python_provide:%python_provide python2-%{srcname}}
-BuildRequires:  %{py2name}-devel
-BuildRequires:  %{py2name}-setuptools, %{py2name}-six
-%if 0%{?rhel} && 0%{?rhel} <= 7
-BuildRequires:  pytest
-%else
-BuildRequires:  python2-pytest
-%endif
-Requires: %{py2name}-six
-
-%description -n python2-%{srcname}
-%{summary}.
-
-Python 2 version.
 
 %if %{with python3}
 %package -n python3-%{srcname}
@@ -60,7 +42,8 @@ Summary:        %{summary}
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
 %if %{with tests}
-BuildRequires:  python3-six, python3-pytest
+BuildRequires:  python3-six
+BuildRequires:  python3-pytest
 %endif
 Requires: python3-six
 
@@ -68,38 +51,52 @@ Requires: python3-six
 %{summary}.
 
 Python 3 version.
+
+%else
+%package -n python2-%{srcname}
+Summary:        %{summary}
+%{?python_provide:%python_provide python2-%{srcname}}
+BuildRequires:  python2-devel
+BuildRequires:  python-setuptools
+%if %{with tests}
+BuildRequires:  python-six
+BuildRequires:  pytest
+%endif
+Requires: python-six
+
+%description -n python2-%{srcname}
+%{summary}.
+
+Python 2 version.
 %endif
 
 %prep
 %setup -n %{srcname}-%{commit}
 
 %build
-%py2_build
 %if %{with python3}
 %py3_build
+%else
+%py2_build
 %endif
 
 %install
-%py2_install
 %if %{with python3}
 %py3_install
+%else
+%py2_install
 %endif
 
 %if %{with tests}
 %check
 export LANG=C.utf8
-py.test-%{python2_version} -v tests
 %if %{with python3}
 py.test-%{python3_version} -v tests
+%else
+py.test-%{python2_version} -v tests
 %endif
 %endif
 
-%files -n %{py2name}-%{srcname}
-%{!?_licensedir:%global license %%doc}
-%license LICENSE
-%doc README.md
-%{python2_sitelib}/%{modname}-*.egg-info/
-%{python2_sitelib}/%{modname}/
 
 %if %{with python3}
 %files -n python3-%{srcname}
@@ -108,6 +105,13 @@ py.test-%{python3_version} -v tests
 %doc README.md
 %{python3_sitelib}/%{modname}-*.egg-info/
 %{python3_sitelib}/%{modname}/
+%else
+%files -n python-%{srcname}
+%{!?_licensedir:%global license %%doc}
+%license LICENSE
+%doc README.md
+%{python2_sitelib}/%{modname}-*.egg-info/
+%{python2_sitelib}/%{modname}/
 %endif
 
 %changelog


### PR DESCRIPTION
and disable fedora 28 testing, build py2 packages only for
rhel <=7, and py3 for fedora and rhel >= 8

Signed-off-by: Robert Cerven <rcerven@redhat.com>