### PR TITLE
Packit config file (.packit.yaml)

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,39 @@
+# https://packit.dev/docs/configuration/
+
+specfile_path: python-dockerfile-parse.spec
+
+# to be copied to dist-git during an update
+synced_files:
+    - python-dockerfile-parse.spec
+    - .packit.yaml
+
+# name in upstream package repository/registry (e.g. in PyPI)
+upstream_project_name: dockerfile-parse
+# name of downstream (Fedora) RPM package
+downstream_package_name: python-dockerfile-parse
+
+# for packit service (Github app)
+jobs:
+- job: sync_from_downstream
+  trigger: commit
+- job: propose_downstream
+  trigger: release
+  metadata:
+    dist-git-branch: master
+- job: propose_downstream
+  trigger: release
+  metadata:
+    dist-git-branch: f31
+- job: propose_downstream
+  trigger: release
+  metadata:
+    dist-git-branch: f30
+- job: copr_build
+  trigger: pull_request
+  metadata:
+    targets:
+    - fedora-rawhide-x86_64
+    - fedora-31-x86_64
+    - fedora-30-x86_64
+    - epel-7-x86_64
+    - rhelbeta-8-x86_64

--- a/python-dockerfile-parse.spec
+++ b/python-dockerfile-parse.spec
@@ -1,9 +1,5 @@
 %if 0%{?rhel} && 0%{?rhel} <= 7
 %bcond_with python3
-%if 0%{?rhel} <= 6
-%{!?python2_version: %global python2_version %(%{__python2} -c "import sys; sys.stdout.write(sys.version[:3])")}
-%{!?_licensedir:%global license %%doc}
-%endif
 %else
 %bcond_without python3
 %endif

--- a/python-dockerfile-parse.spec
+++ b/python-dockerfile-parse.spec
@@ -1,24 +1,23 @@
 %if 0%{?rhel} && 0%{?rhel} <= 7
-%{!?py2_build: %global py2_build %{__python2} setup.py build}
-%{!?py2_install: %global py2_install %{__python2} setup.py install --skip-build --root %{buildroot}}
 %bcond_with python3
 %if 0%{?rhel} <= 6
-%{!?__python2: %global __python2 /usr/bin/python2}
-%{!?python2_sitelib: %global python2_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
-%{!?python2_sitearch: %global python2_sitearch %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
 %{!?python2_version: %global python2_version %(%{__python2} -c "import sys; sys.stdout.write(sys.version[:3])")}
+%{!?_licensedir:%global license %%doc}
 %endif
 %else
 %bcond_without python3
+%endif
+
+%if 0%{?fedora} && 0%{?fedora} >= 30
+%bcond_with python2
+%else
+%bcond_without python2
 %endif
 
 %bcond_without tests
 
 %global srcname dockerfile-parse
 %global modname %(n=%{srcname}; echo ${n//-/_})
-
-%global commit 256e7fc490a8accda0b6b6f84436b0dcd4d7b707
-%global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           python-%{srcname}
 Version:        0.0.15
@@ -27,13 +26,33 @@ Release:        1%{?dist}
 Summary:        Python library for Dockerfile manipulation
 License:        BSD
 URL:            https://github.com/containerbuildsystem/dockerfile-parse
-Source0:        %{url}/archive/%{commit}/%{srcname}-%{commit}.tar.gz
+Source0:        %{url}/archive/%{version}/%{srcname}-%{version}.tar.gz
 
 BuildArch:      noarch
 
 %description
 %{summary}.
 
+%if %{with python2}
+%package -n python2-%{srcname}
+Summary:        %{summary}
+%{?python_provide:%python_provide python2-%{srcname}}
+BuildRequires:  python2-devel
+BuildRequires:  python2-six
+%if 0%{?rhel} && 0%{?rhel} <= 7
+BuildRequires:  python-setuptools
+BuildRequires:  pytest
+%else
+BuildRequires:  python2-setuptools
+BuildRequires:  python2-pytest
+%endif
+Requires:  python2-six
+
+%description -n python2-%{srcname}
+%{summary}.
+
+Python 2 version.
+%endif # python2 pkg
 
 %if %{with python3}
 %package -n python3-%{srcname}
@@ -42,76 +61,62 @@ Summary:        %{summary}
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
 %if %{with tests}
-BuildRequires:  python3-six
 BuildRequires:  python3-pytest
+BuildRequires:  python3-six
 %endif
-Requires: python3-six
+Requires:  python3-six
 
 %description -n python3-%{srcname}
 %{summary}.
 
 Python 3 version.
-
-%else
-%package -n python2-%{srcname}
-Summary:        %{summary}
-%{?python_provide:%python_provide python2-%{srcname}}
-BuildRequires:  python2-devel
-BuildRequires:  python-setuptools
-%if %{with tests}
-BuildRequires:  python-six
-BuildRequires:  pytest
-%endif
-Requires: python-six
-
-%description -n python2-%{srcname}
-%{summary}.
-
-Python 2 version.
-%endif
+%endif #python3 pkg
 
 %prep
-%setup -n %{srcname}-%{commit}
+%setup -q -n %{srcname}-%{version}
+
 
 %build
+%if %{with python2}
+%py2_build
+%endif # python2
 %if %{with python3}
 %py3_build
-%else
-%py2_build
 %endif
 
 %install
+%if %{with python2}
+%py2_install
+%endif #python2
 %if %{with python3}
 %py3_install
-%else
-%py2_install
 %endif
 
 %if %{with tests}
 %check
-export LANG=C.utf8
+export LANG=C.UTF-8
+%if %{with python2}
+py.test-%{python2_version} -v tests
+%endif # python2
 %if %{with python3}
 py.test-%{python3_version} -v tests
-%else
-py.test-%{python2_version} -v tests
-%endif
+%endif # python3
 %endif
 
-
-%if %{with python3}
-%files -n python3-%{srcname}
-%{!?_licensedir:%global license %%doc}
-%license LICENSE
-%doc README.md
-%{python3_sitelib}/%{modname}-*.egg-info/
-%{python3_sitelib}/%{modname}/
-%else
-%files -n python-%{srcname}
-%{!?_licensedir:%global license %%doc}
+%if %{with python2}
+%files -n python2-%{srcname}
 %license LICENSE
 %doc README.md
 %{python2_sitelib}/%{modname}-*.egg-info/
 %{python2_sitelib}/%{modname}/
+%endif
+
+%if %{with python3}
+%files -n python3-%{srcname}
+%license LICENSE
+%doc README.md
+%{python3_sitelib}/%{modname}-*.egg-info/
+%{python3_sitelib}/%{modname}/
 %endif
 
 %changelog


### PR DESCRIPTION
[Packit](https://packit.dev) is a [Github App](https://github.com/marketplace/packit-as-a-service) which helps you integrate this project/package downstream (Fedora).

Just add a config (i.e. merge this) and install the [Github App](https://github.com/marketplace/packit-as-a-service) in this repo.
There are several [jobs](https://packit.dev/docs/configuration/#supported-jobs) in the config file, which tell the service what to do:
- `[copr_build]` anytime a PR is created/updated, Packit builds RPM packages in [copr](https://github.com/marketplace/packit-as-a-service) and lets you know whether everything's still ok.
- `[propose_downstream]` (not implemented yet, but soon :-) ) when a release is created, Packit creates PR's in [Fedora dist-git](https://src.fedoraproject.org/rpms/python-dockerfile-parse)
- `[sync_from_downstream]` picks up a change (mass rebuild, proven packager rebuild or a fix) from Fedora dist-git and sends it to this repo