### PR TITLE
[__init__.py] get __version__ from distribution

### DIFF
--- a/dockerfile_parse/__init__.py
+++ b/dockerfile_parse/__init__.py
@@ -8,4 +8,10 @@ of the BSD license. See the LICENSE file for details.
 
 from .parser import DockerfileParser
 
-__version__ = "0.0.15"
+from pkg_resources import get_distribution, DistributionNotFound
+
+try:
+    __version__ = get_distribution(__name__).version
+except DistributionNotFound:
+    # package is not installed
+    pass


### PR DESCRIPTION
[TestDockerfileParser.test_all_versions_match()](https://github.com/containerbuildsystem/dockerfile-parse/blob/master/tests/test_parser.py#L33) already covers this.

I'm opening this PR just to test [Packit](https://packit.dev) once #83 is merged and [Packit](https://github.com/marketplace/packit-as-a-service) is installed in this repo.
I'll let you know when this can be merged.