### PR TITLE
Update the regex for instruction name.

### DIFF
--- a/dockerfile_parse/parser.py
+++ b/dockerfile_parse/parser.py
@@ -240,7 +240,7 @@ class DockerfileParser(object):
 
         instructions = []
         lineno = -1
-        insnre = re.compile(r'^\s*(\w+)\s+(.*)$')  # matched group is insn
+        insnre = re.compile(r'^\s*(\S+)\s+(.*)$')  # matched group is insn
         contre = re.compile(r'^.*\\\s*$')          # line continues?
         commentre = re.compile(r'^\s*#')           # line is a comment?
         

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -183,6 +183,24 @@ class TestDockerfileParser(object):
                                        'content': 'RUN command4 && \\\n    command5\n',
                                        'value': 'command4 &&     command5'}]
 
+    def test_invalid_dockerfile_structure(self, dfparser):
+        '''Invalid instruction is reserverd.'''
+        dfparser.content = dedent("""\
+            RUN apt-get update
+                apt-get install something
+            """)
+        assert dfparser.structure == [
+                                      {'instruction': 'RUN',
+                                       'startline': 0,
+                                       'endline': 0,
+                                       'content': 'RUN apt-get update\n',
+                                       'value': 'apt-get update'},
+                                      {'instruction': 'APT-GET',
+                                       'startline': 1,
+                                       'endline': 1,
+                                       'content': '    apt-get install something\n',
+                                       'value': 'install something'}]
+
     def test_dockerfile_json(self, dfparser):
         dfparser.content = dedent("""\
             # comment


### PR DESCRIPTION
Previous "\w+" cannot match invalid name, such as "apt-get", which may be introduced by mistake.
Use "\S+" to be more robust.

Signed-off-by: limjcst <limjcst@163.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
