### PR TITLE
Add support for custom tito builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ downloads/
 eggs/
 .eggs/
 lib/
+!rel-eng/lib/
 lib64/
 parts/
 sdist/

--- a/python-dockerfile-parse.spec
+++ b/python-dockerfile-parse.spec
@@ -22,7 +22,7 @@ Release:        1%{?dist}
 Summary:        Python library for Dockerfile manipulation
 License:        BSD
 URL:            https://github.com/containerbuildsystem/dockerfile-parse
-Source0:        %{url}/archive/%{version}/%{srcname}-%{version}.tar.gz
+Source0:        https://github.com/containerbuildsystem/dockerfile-parse/archive/%{version}.tar.gz
 
 BuildArch:      noarch
 
@@ -71,7 +71,7 @@ Python 3 version.
 %endif #python3 pkg
 
 %prep
-%setup -q -n %{srcname}-%{version}
+%setup -q
 
 
 %build

--- a/rel-eng/lib/osbsbuilder.py
+++ b/rel-eng/lib/osbsbuilder.py
@@ -1,0 +1,12 @@
+from tito.builder import Builder
+
+
+class DockerfileParseBuilder(Builder):
+
+    def __init__(self, **kwargs):
+        super(DockerfileParseBuilder, self).__init__(**kwargs)
+        # tarball has to represent Source0
+        # but internal structure should remain same
+        # i.e. {name}-{version} otherwise %setup -q
+        # will fail
+        self.tgz_filename = self.display_version + ".tar.gz"

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -1,9 +1,10 @@
 [buildconfig]
-builder = tito.builder.Builder
+builder = osbsbuilder.DockerfileParseBuilder
 tagger = tito.tagger.VersionTagger
 changelog_do_not_remove_cherrypick = 0
 changelog_format = %s (%ae)
 tag_format = {version}
+lib_dir = rel-eng/lib
 
 [version_template]
 destination_file = ./dockerfile_parse/__init__.py


### PR DESCRIPTION
Tito cannot handle if release tags are different from {name}-{version},
thus custom builder is needed.

Signed-off-by: Martin Bašti <mbasti@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
