### PR TITLE
Enable Markdown linter (remark-lint) for Stickler CI

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,19 @@
+{
+  "plugins": [
+    "remark-preset-lint-markdown-style-guide",
+    "remark-lint-no-dead-urls",
+    "remark-lint-match-punctuation",
+    "remark-lint-mdash-style",
+    "remark-lint-no-chinese-punctuation-in-number",
+    "remark-lint-no-dead-urls",
+    "remark-lint-no-repeat-punctuation",
+    "remark-lint-emoji-limit",
+    "remark-lint-no-empty-sections",
+    "remark-lint-heading-length",
+    "remark-lint-heading-whitespace",
+    "remark-lint-are-links-valid",
+    "remark-lint-spaces-around-number",
+    "remark-lint-spaces-around-word",
+    "remark-lint-no-url-trailing-slash"
+  ]
+}

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -3,3 +3,4 @@ linters:
     max-line-length: 99
   shellcheck:
     shell: bash
+  remarklint:


### PR DESCRIPTION
Signed-off-by: Ben Alkov <ben.alkov@redhat.com>



Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [ ] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
