### PR TITLE
Fix 'invalid escape sequence' warning

### DIFF
--- a/dockerfile_parse/parser.py
+++ b/dockerfile_parse/parser.py
@@ -233,7 +233,7 @@ class DockerfileParser(object):
             }
 
         def _clean_comment_line(line):
-            line = re.sub('^\s*#\s*', '', line)
+            line = re.sub(r'^\s*#\s*', '', line)
             line = re.sub('\n', '', line)
             return line
 


### PR DESCRIPTION
When running tests on py 3.8, I get the following warning:

  /home/amezin/dockerfile-parse/dockerfile_parse/parser.py:236: DeprecationWarning: invalid escape sequence \s
    line = re.sub('^\s*#\s*', '', line)

Apparently, this should be a raw literal


Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
