### PR TITLE
Replace "Signed-off-by:" maintainer task with DCO...

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,5 +1,4 @@
 # Maintainers will complete the following section
 
 - [ ] Commit messages are descriptive enough
-- [ ] "Signed-off-by:" line is present in each commit
 - [ ] Code coverage from testing does not decrease and new code is covered


### PR DESCRIPTION
...GitHub Action

* CLOUDBLD-766

Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
