### PR TITLE
Complete support for ARG statement handling

### DIFF
--- a/dockerfile_parse/parser.py
+++ b/dockerfile_parse/parser.py
@@ -70,6 +70,26 @@ class Envs(dict):
         self.parser.envs = dict(self)
 
 
+class Args(dict):
+    """
+    A class for allowing direct write access to Dockerfile args, e.g.:
+
+    parser.args['variable_name'] = 'value'
+    """
+
+    def __init__(self, args, parser):
+        super(Args, self).__init__(args)
+        self.parser = parser
+
+    def __delitem__(self, key):
+        super(Args, self).__delitem__(key)
+        self.parser.envs = dict(self)
+
+    def __setitem__(self, key, value):
+        super(Args, self).__setitem__(key, value)
+        self.parser.envs = dict(self)
+
+
 class DockerfileParser(object):
     def __init__(self, path=None,
                  cache_content=False,
@@ -304,6 +324,10 @@ class DockerfileParser(object):
                 continue
             image, _ = image_from(instr['value'])
             if image is not None:
+                # replace any ARG keys with values
+                for key in self.args.keys():
+                    pattern = '\\$'+key+'|'+'\\${'+key+'}'
+                    image = re.sub(pattern, self.args[key], image)
                 parents.append(image)
         return parents
 
@@ -414,6 +438,14 @@ class DockerfileParser(object):
         """
         return self._instruction_getter('ENV', env_replace=self.env_replace)
 
+    @property
+    def args(self):
+        """
+        ARGs from Dockerfile
+        :return: dictionary of arg_var_name:value (value might be '')
+        """
+        return self._instruction_getter('ARG', env_replace=self.env_replace)
+
     def _instruction_getter(self, name, env_replace):
         """
         Get LABEL or ENV instructions with environment replacement
@@ -422,17 +454,17 @@ class DockerfileParser(object):
         :param env_replace: bool, whether to perform ENV substitution
         :return: Labels instance or Envs instance
         """
-        if name != 'LABEL' and name != 'ENV':
-            raise ValueError("Unsupported instruction '%s'" % name)
+        supported_instrs = ('LABEL', 'ENV', 'ARG')
+        if name not in supported_instrs:
+            raise ValueError("Unsupported instruction '%s'", name)
         instructions = {}
         envs = {}
 
         for instruction_desc in self.structure:
             this_instruction = instruction_desc['instruction']
             if this_instruction == 'FROM':
-                instructions.clear()
                 envs = self.parent_env.copy()
-            elif this_instruction in (name, 'ENV'):
+            elif this_instruction in supported_instrs:
                 logger.debug("%s value: %r", name.lower(), instruction_desc['value'])
                 key_val_list = extract_labels_or_envs(env_replace=env_replace,
                                                       envs=envs,
@@ -445,7 +477,12 @@ class DockerfileParser(object):
                         envs[key] = value
 
         logger.debug("instructions: %r", instructions)
-        return Labels(instructions, self) if name == 'LABEL' else Envs(instructions, self)
+        if name == 'LABEL':
+            return Labels(instructions, self)
+        elif name == 'ENV':
+            return Envs(instructions, self)
+        else:
+            return Args(instructions, self)
 
     @labels.setter
     def labels(self, labels):

--- a/test.sh
+++ b/test.sh
@@ -71,6 +71,7 @@ function setup_dfp() {
 
   # CentOS needs to have setuptools updates to make pytest-cov work
   if [[ $OS != "fedora" ]]; then
+    $RUN $PIP install -U pip
     $RUN $PIP install -U setuptools
 
     # Watch out for https://github.com/pypa/setuptools/issues/937

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -36,7 +36,7 @@ def dfparser(tmpdir, request):
         return DockerfileParser(path=tmpdir_path, cache_content=cache_content)
 
 
-@pytest.fixture(params=['LABEL', 'ENV'])
+@pytest.fixture(params=['LABEL', 'ENV', 'ARG'])
 def instruction(request):
     """
     Parametrized fixture which enables to run a test once for each instruction in params


### PR DESCRIPTION
This started with the branch @nishakm submitted, but adds complete support for ARGs usage in all the same places ENVs are currently supported. It also enhanced all ENV pytests to also test ARGs, and ensured pytests have 100% coverage.

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
