### PR TITLE
test.sh: add repo dir as safe directory

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -85,6 +85,8 @@ case ${ACTION} in
 "bandit")
   setup_dfp
   $RUN $PKG install -y git-core
+  # workaround for https://github.com/actions/checkout/issues/766
+  $RUN git config --global --add safe.directory "$PWD"
   $RUN $PIP install 'bandit<1.6.3'
   TEST_CMD="bandit-baseline -r dockerfile_parse -ll -ii"
   ;;


### PR DESCRIPTION
See https://github.com/containerbuildsystem/atomic-reactor/pull/1896

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
