### PR TITLE
workflow: use checkout action version 3

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -28,7 +28,9 @@ jobs:
             engine: docker
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - run: ./test.sh
         env:
@@ -44,7 +46,7 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run flake8 for Python 3
         uses: containerbuildsystem/actions/flake8@master
@@ -55,7 +57,7 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run markdownlint
         uses: containerbuildsystem/actions/markdownlint@master
@@ -78,7 +80,7 @@ jobs:
             engine: docker
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - run: ./test.sh
         env:
@@ -94,7 +96,7 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run ShellCheck
         uses: containerbuildsystem/actions/shellcheck@master

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: pytests via test.sh
         env:

--- a/dockerfile_parse/parser.py
+++ b/dockerfile_parse/parser.py
@@ -274,7 +274,7 @@ class DockerfileParser(object):
         syntax_directive_re = re.compile(r'^\s*#\s*syntax\s*=\s*(.*)\s*$', re.I)
 
         in_continuation = False
-        current_instruction = None
+        current_instruction = {}
 
         for line in self.lines:
             lineno += 1
@@ -316,16 +316,14 @@ class DockerfileParser(object):
                     current_instruction['content'] += line
                     current_instruction['endline'] = lineno
 
-                    # pylint: disable=unsupported-assignment-operation
                     if current_instruction['value']:
                         current_instruction['value'] += _rstrip_eol(line, line_continuation_char)
                     else:
                         current_instruction['value'] = _rstrip_eol(line.lstrip(),
                                                                    line_continuation_char)
-                    # pylint: enable=unsupported-assignment-operation
 
                 in_continuation = contre.match(line)
-                if not in_continuation and current_instruction is not None:
+                if not in_continuation and current_instruction:
                     instructions.append(current_instruction)
 
         return instructions


### PR DESCRIPTION
Older versions run with unsupported nodejs

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
