### PR TITLE
Automatic updates of GH actions with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -312,7 +312,6 @@ class TestDockerfileParser(object):
         dfparser.lines = ["From fedora:latest\n",
                           "LABEL a b\n"]
         assert dfparser.baseimage == 'fedora:latest'
-        
 
     def test_get_baseimg_from_df_with_platform(self, dfparser):
         dfparser.lines = ["From --platform=linux/amd64 fedora:latest\n",


### PR DESCRIPTION
Dependabot can do automatic updates of GH actions for us

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
