### PR TITLE
Run the linter and unit tests on a pull request.

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -2,7 +2,9 @@ name: Linters
 
 on:
   pull_request:
-
+    branches:
+      - master
+      - release_*
   push:
     branches:
       - master

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -2,12 +2,18 @@ name: Unittests
 
 on:
   pull_request:
-
+    branches:
+      - master
+      - release_*
+    paths:
+      - '**.py'
   push:
     branches:
       - master
       - release_*
-
+    paths:
+      - '**.py'
+      
 jobs:
   test:
     name: Python ${{ matrix.os.python }} tests on ${{ matrix.os.name }}-${{ matrix.os.version }}


### PR DESCRIPTION
Since my previous PR created linter errors on master & release_*: 
Both linter & unittests now run on pull requests. 
Unittests only run on changed .py file.
Linter always runs 

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
