### PR TITLE
fix(spec): remove six module

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -76,4 +76,3 @@ ignored-modules=requests.packages,
                 responses,
                 docker,
                 http.client,
-                six.moves

--- a/python-dockerfile-parse.spec
+++ b/python-dockerfile-parse.spec
@@ -24,9 +24,7 @@ BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
 %if %{with tests}
 BuildRequires:  python3-pytest
-BuildRequires:  python3-six
 %endif
-Requires:  python3-six
 
 %description -n python3-%{srcname}
 %{summary}.

--- a/test.sh
+++ b/test.sh
@@ -47,10 +47,6 @@ function setup_dfp() {
   # Install dependencies
   $RUN $PKG install -y "${PKG_EXTRA[@]}"
   $RUN $"${BUILDDEP[@]}" -y python-dockerfile-parse.spec
-  if [[ $OS = "centos" ]]; then
-    # Install dependecies for test, as check is disabled for rhel
-    $RUN yum install -y python-six
-  fi
 
   # Install pip package
   $RUN $PKG install -y $PIP_PKG

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -37,7 +37,7 @@ class TestDockerfileParser(object):
                 if len(found) == 1:
                     return found[0]
                 else:
-                    raise Exception("Version not found!")
+                    raise RuntimeError("Version not found!")
 
         import dockerfile_parse
         from dockerfile_parse import __version__ as module_version


### PR DESCRIPTION
Dockerfile-parse is py3 only, we don't need python-six anymore

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
