### PR TITLE
Improve handling of file names and paths

### DIFF
--- a/dockerfile_parse/parser.py
+++ b/dockerfile_parse/parser.py
@@ -9,8 +9,8 @@ of the BSD license. See the LICENSE file for details.
 
 import json
 import logging
-import os
 import re
+from pathlib import Path
 from contextlib import contextmanager
 from shlex import quote
 
@@ -100,6 +100,7 @@ class DockerfileParser(object):
         """
 
         self.fileobj = fileobj
+        self.dockerfile = None
 
         if self.fileobj is not None:
             if path is not None:
@@ -107,11 +108,11 @@ class DockerfileParser(object):
             else:
                 self.fileobj.seek(0)
         else:
-            path = path or '.'
-            if path.endswith(DOCKERFILE_FILENAME):
-                self.dockerfile_path = path
+            path = Path(path) or Path.cwd()
+            if path.name.endswith(DOCKERFILE_FILENAME):
+                self.dockerfile = path
             else:
-                self.dockerfile_path = os.path.join(path, DOCKERFILE_FILENAME)
+                self.dockerfile = path / DOCKERFILE_FILENAME
 
         self.cache_content = cache_content
         self.cached_content = ''  # unicode string
@@ -149,8 +150,19 @@ class DockerfileParser(object):
             yield self.fileobj
             self.fileobj.seek(0)
         else:
-            with open(self.dockerfile_path, mode) as dockerfile:
+            with self.dockerfile.open(mode) as dockerfile:
                 yield dockerfile
+
+    @property
+    def dockerfile_path(self):
+        """
+        :return: Path to the Dockerfile as a string, or None if using fileobj
+        """
+        return str(self.dockerfile) if self.dockerfile else None
+
+    @dockerfile_path.setter
+    def dockerfile_path(self, value):
+        self.dockerfile = Path(value) if value else None
 
     @property
     def lines(self):

--- a/dockerfile_parse/parser.py
+++ b/dockerfile_parse/parser.py
@@ -85,7 +85,8 @@ class DockerfileParser(object):
                  env_replace=True,
                  parent_env=None,
                  fileobj=None,
-                 build_args=None):
+                 build_args=None,
+                 dockerfile_filename=DOCKERFILE_FILENAME):
         """
         Initialize source of Dockerfile
         :param path: path to (directory with) Dockerfile; if not provided,
@@ -97,6 +98,8 @@ class DockerfileParser(object):
         :param fileobj: seekable file-like object containing Dockerfile content
                         as bytes (will be truncated on write)
         :param build_args: python dict of build args used when building image
+        :param dockerfile_filename: name of the dockerfile to discover or create
+                                    in the path (default: Dockerfile)
         """
 
         self.fileobj = fileobj
@@ -109,10 +112,10 @@ class DockerfileParser(object):
                 self.fileobj.seek(0)
         else:
             path = Path(path) or Path.cwd()
-            if path.name.endswith(DOCKERFILE_FILENAME):
+            if path.name.endswith(dockerfile_filename):
                 self.dockerfile = path
             else:
-                self.dockerfile = path / DOCKERFILE_FILENAME
+                self.dockerfile = path / dockerfile_filename
 
         self.cache_content = cache_content
         self.cached_content = ''  # unicode string

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -14,6 +14,7 @@ import os
 import pytest
 import re
 import sys
+from pathlib import Path
 from textwrap import dedent
 
 from dockerfile_parse import DockerfileParser
@@ -1521,3 +1522,18 @@ class TestDockerfileParser(object):
 
         validate = DockerfileParser(path=tmpdir, dockerfile_filename="Containerfile")
         assert validate.baseimage == out.baseimage
+
+    def test_dockerfile_path_compatibility(self, tmpdir):
+        tmpdir = Path(tmpdir)
+        parser = DockerfileParser(path=tmpdir)
+        assert str(parser.dockerfile) == parser.dockerfile_path
+        assert parser.dockerfile == tmpdir / "Dockerfile"
+
+        with (tmpdir / "nothing").open("w+") as testfile:
+            nullparser = DockerfileParser(fileobj=testfile)
+            assert nullparser.dockerfile is None
+            assert nullparser.dockerfile_path is None
+
+        newfile = tmpdir / "nowhere"
+        parser.dockerfile_path = str(newfile)
+        assert parser.dockerfile == newfile

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1509,3 +1509,15 @@ class TestDockerfileParser(object):
                 'value': 'touch foo;     touch bar'
             }
         ]
+
+    def test_alt_dockerfile_names(self, tmpdir):
+        tmpdir = Path(tmpdir)
+        content = "FROM fedora:38"
+        out = DockerfileParser(path=tmpdir, dockerfile_filename="Containerfile")
+        out.content = content
+
+        assert out.dockerfile == tmpdir / "Containerfile"
+        assert out.dockerfile.is_file()
+
+        validate = DockerfileParser(path=tmpdir, dockerfile_filename="Containerfile")
+        assert validate.baseimage == out.baseimage


### PR DESCRIPTION
Thank you so much for making this project! Each commit in this PR is self contained and could be reviewed separately, let me know if there's anything I can do to make the review process easier.

**Summary of changes:**

* Update `DockerfileParser` class to use `pathlib.Path` objects for file read/write operations
* Add `DockerfileParser.dockerfile` attribute to expose the path to the Dockerfile as a `pathlib.Path` object while maintaining backwards compatibility with the existing `DockerfileParser.dockerfile_path` property as a string
* Add `dockerfile_filename` keyword to `DockerfileParser.__init__()` to allow users to provide an alternative name for their dockerfile (ex: `Dockerfile.dev`, `Dockerfile.sample`, `Containerfile`, etc) while maintaining backwards compatibility with the existing default of `Dockerfile`
* Add tests for these new features

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
